### PR TITLE
Allow custom class names in the container

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,80 @@
+/**
+ * Created by victor on 11/17/16.
+ */
+module.exports = function (config) {
+  var webpack = require('webpack');
+  var path = require('path');
+
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: './',
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+    // list of files / patterns to load in the browser
+    files: [
+      {pattern: 'src/**/*-spec.js', included: true}
+    ],
+
+    // list of files to exclude
+    exclude: ['src/**/*-mobile*', 'src/**/*-desktop*'],
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+      'src/**/*-spec.js': ['webpack']
+    },
+
+    webpack: {
+      devtool: 'eval',
+      cache: true,
+      failOnError: false,
+      module: {
+        loaders: [
+          {test: /\.js$/, exclude: /node_modules|bower_components/, loader: 'babel-loader'}
+        ]
+      },
+      plugins: [
+        new webpack.PrefetchPlugin('react')
+      ]
+    },
+
+    webpackServer: {
+      noInfo: true, //please don't spam the console when running in karma!
+    },
+
+    browserNoActivityTimeout: 200000,
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress', 'junit'],
+
+    // web server port
+    port: 9876,
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    junitReporter : {
+      outputFile: 'target/reports/unit-test-results.xml'
+    },
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['chrome'],
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true
+  });
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "NODE_ENV=production npm run clean && npm run babel && webpack --config webpack.prod.config.js",
     "testDesktop": "NODE_ENV=test karma start karma.conf.desktop.js --browsers desktop",
     "testMobile": "NODE_ENV=test karma start karma.conf.mobile.js --browsers mobile",
-    "test": "npm run testDesktop && npm run testMobile",
+    "test": "npm run testDesktop && npm run testMobile && NODE_ENV=test karma start karma.conf.js --browsers Chrome",
     "prepublish": "npm run lint && npm test && npm build"
   },
   "main": "lib/index.js",

--- a/src/match-media/MatchMedia-spec.js
+++ b/src/match-media/MatchMedia-spec.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+import MatchMedia from './MatchMedia';
+
+describe('MatchMedia', function () {
+  let page;
+
+  beforeEach(function () {
+    page = ReactTestUtils.renderIntoDocument(
+      <MatchMedia className="testClass" mediaQuery={'(min-width: 0px)'}>
+        <div className="testDiv" />
+      </MatchMedia>);
+  });
+
+  it('allows to add custom class names to the container', function () {
+    let testElement = ReactTestUtils.findRenderedDOMComponentWithClass(page, 'testClass');
+    expect(testElement).toBeDefined();
+  });
+});

--- a/src/match-media/MatchMedia.js
+++ b/src/match-media/MatchMedia.js
@@ -28,7 +28,7 @@ export default class MatchMedia extends Component {
     if (!this.props.children || !isClient() || !this.state.show) return false;
 
     return(
-      <div className="match-media">
+      <div className={`${this.props.className || ''} match-media`.trim()}>
         {this.props.children}
       </div>
     );
@@ -36,6 +36,7 @@ export default class MatchMedia extends Component {
 }
 
 MatchMedia.propTypes = {
+  className: React.PropTypes.string,
   mediaQuery: React.PropTypes.string.isRequired
 };
 


### PR DESCRIPTION
This PR allows to add custom class names to the container `div` that the `<MatchMedia />` component creates to wrap the children. 

It still keeps the `match-media` class.

For tests, I created a new karma config file and a `MatchMedia-spec.js` file. As I felt that the test case didn't match in any of the existing test files, as they were specific for certain window dimensions.