### PR TITLE
Specify better dependency range

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,16 +42,18 @@
     "karma-junit-reporter": "^0.3.8",
     "karma-spec-reporter": "0.0.26",
     "karma-webpack": "^1.7.0",
-    "react-addons-test-utils": "^0.14.2",
+    "react": "^15.4.2",
+    "react-addons-test-utils": "^15.4.2",
+    "react-dom": "^15.4.2",
     "react-hot-loader": "^1.3.0",
     "watch": "^0.17.1",
     "webpack": "^1.12.2",
     "webpack-dev-middleware": "^1.5.0",
     "webpack-hot-middleware": "^2.6.0"
   },
-  "dependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+  "peerDependencies": {
+    "react": "^0.14.0 || ^15.0.0-0",
+    "react-dom": "^0.14.0 || ^15.0.0-0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently, the dependency specification for react and react-dom
is too strict. As a user of React v15.4.2, `react-match-media` forces
an inclusion of React `^0.14.0` in the package, leading ~600kb of
extra waste in my bundle. This commit loosens the constraints;
following the same version constraints as `react-redux`.